### PR TITLE
Updated Hungarian translation.

### DIFF
--- a/Kernel/Language/hu_MasterSlave.pm
+++ b/Kernel/Language/hu_MasterSlave.pm
@@ -25,7 +25,7 @@ sub Data {
 
     # Template: AgentTicketMasterSlave
     $Self->{Translation}->{'Manage Master/Slave status for %s%s%s'} = '%s%s%s mester/alárendelt állapotának kezelése';
-    $Self->{Translation}->{'All fields marked with an asterisk (*) are mandatory.'} = '';
+    $Self->{Translation}->{'All fields marked with an asterisk (*) are mandatory.'} = 'A csillaggal (*) megjelölt összes mező kötelező.';
 
     # Perl Module: Kernel/Modules/AgentTicketMasterSlave.pm
     $Self->{Translation}->{'New Master Ticket'} = 'Új mesterjegy';
@@ -118,7 +118,7 @@ sub Data {
     $Self->{Translation}->{'This module activates Master/Slave field in new email and phone ticket screens.'} =
         'Ez a modul bekapcsolja a mester/alárendelt mezőt az új e-mail és telefonos jegy képernyőkön.';
     $Self->{Translation}->{'This setting is deprecated and will be removed in further versions of MasterSlave.'} =
-        'Ez a beállítás elavult, és el lesz távolítva az MasterSlave későbbi verzióiból.';
+        'Ez a beállítás elavult, és el lesz távolítva a MasterSlave csomag későbbi verzióiból.';
     $Self->{Translation}->{'Ticket MasterSlave.'} = 'Jegy mester-alárendelt.';
 
 

--- a/i18n/MasterSlave/MasterSlave.hu.po
+++ b/i18n/MasterSlave/MasterSlave.hu.po
@@ -2,13 +2,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MasterSlave\n"
 "POT-Creation-Date: 2024-05-25 05:17+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2026-05-21 10:45+0200\n"
+"Last-Translator: Balázs Úr <balazs@urbalazs.hu>\n"
+"Language-Team: Hungarian <https://translate.otobo.org/projects/opm-packages/masterslave/hu/>\n"
+"Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 25.12.3\n"
 
 #. Template: AgentTicketMasterSlave
 msgid "Manage Master/Slave status for %s%s%s"
@@ -16,7 +18,7 @@ msgstr "%s%s%s mester/alárendelt állapotának kezelése"
 
 #. Template: AgentTicketMasterSlave
 msgid "All fields marked with an asterisk (*) are mandatory."
-msgstr ""
+msgstr "A csillaggal (*) megjelölt összes mező kötelező."
 
 #. Perl Module: Kernel/Modules/AgentTicketMasterSlave.pm
 msgid "New Master Ticket"
@@ -228,7 +230,7 @@ msgstr "Ez a modul bekapcsolja a mester/alárendelt mezőt az új e-mail és tel
 
 #. SysConfig
 msgid "This setting is deprecated and will be removed in further versions of MasterSlave."
-msgstr "Ez a beállítás elavult, és el lesz távolítva az MasterSlave későbbi verzióiból."
+msgstr "Ez a beállítás elavult, és el lesz távolítva a MasterSlave csomag későbbi verzióiból."
 
 #. SysConfig
 msgid "Ticket MasterSlave."


### PR DESCRIPTION
Updated Hungarian translation for `rel-10_1`. I send this translation via pull request since Weblate handles translations for `rel-11_0` only.

No need to cherry-pick, `rel_11_0` is already updated via Weblate.